### PR TITLE
Update installation instructions

### DIFF
--- a/source/installation/with/source-code.html.md
+++ b/source/installation/with/source-code.html.md
@@ -10,21 +10,21 @@ cd Plume
 ```
 
 Then, you'll need to install Plume and the CLI tools to manage your instance.
-Run the following commands, replacing `DATABASE` either by `postgres` or `sqlite`
-depending on what you want to use.
+Run the following commands.
 
 ```bash
 # Install diesel, a tool to manage your database
+# Replace DATABASE with either postgres or sqlite depending on what you want to use
 cargo install diesel_cli --no-default-features --features DATABASE --version '=1.3.0'
 
 # Build the front-end
 cargo install cargo-web
 cargo web deploy -p plume-front
 
-# Build the back-end
+# Build the back-end, replacing DATABASE with your choice from installing diesel
 cargo install --no-default-features --features DATABASE
 
-# Build plm, the CLI helper
+# Build plm, the CLI helper, replacing DATABASE again
 cargo install --no-default-features --features DATABASE --path plume-cli
 ```
 


### PR DESCRIPTION
Moves the note about replacing the `DATABASE` placeholder closer to the commands that reference it.