### PR TITLE
HTML only wants one h1 per document

### DIFF
--- a/source/development.html.md
+++ b/source/development.html.md
@@ -80,12 +80,12 @@ plume.two:443 {
 Eventually replace the ports in the `proxy` blocks by the one of your two instances, and
 then run `caddy`. You can now open your browser and load `https://plume.one` and `https://plume.two`.
 
-# Running tests
+## Running tests
 
 To run tests of `plume-models` use `RUST_TEST_THREADS=1`, otherwise tests are run
 concurrently, which causes error because they all use the same database.
 
-# Internationalization
+## Internationalization
 
 To mark a string as translatable wrap it in the `i18n!` macro. The first argument
 should be the catalog to load translations from (usually `ctx.1` in templates), the
@@ -96,7 +96,7 @@ as the third arguments, and the number of element as the first format argument.
 
 You can find example uses of this macro [here](https://github.com/Plume-org/gettext-macros#example)
 
-# Working with the front-end
+## Working with the front-end
 
 When working with the front-end, we try limit our use of JavaScript as much as possible.
 Actually, we are not even using JavaScript since our front-end also uses Rust thanks to WebAssembly.
@@ -112,7 +112,7 @@ and not `plume(build)` (next to the progress bar).
 Also, templates are using the Ructe syntax, which is a mix of Rust and HTML. They are compiled to Rust
 and embedded in Plume, which means you have to re-run `cargo` everytime you make a change to the templates.
 
-# Code Style
+## Code Style
 
 For Rust, use the standard style. `rustfmt` can help you keeping your code clean.
 

--- a/source/installation/init.html.md
+++ b/source/installation/init.html.md
@@ -11,7 +11,7 @@ to start other program automatically and to let you manage them more easily.
   <li><a href="/installation/init/openrc">OpenRC</a></li>
 </ul>
 
-# How to know which init system I have?
+## How to know which init system I have?
 
 You can use this little script.
 

--- a/source/installation/proxy.html.md
+++ b/source/installation/proxy.html.md
@@ -17,7 +17,7 @@ your reverse proxy in this list:
 If you don't have a reverse-proxy on your server yet but want one, we recommend
 Caddy as the configuration is really simple.
 
-# How to know which reverse proxy I have?
+## How to know which reverse proxy I have?
 
 This command should give you (most of the time) what your reverse-proxy is.
 

--- a/source/organization/code-of-conduct.html.md
+++ b/source/organization/code-of-conduct.html.md
@@ -6,13 +6,13 @@ summary: 'Our Code of Conduct, based on the Contributor Covenant CoC'
 
 Here is Plume's code of conduct. Please read it before contributing, and make sure you understand and accept it.
 
-# Contributor Covenant Code of Conduct
+## Contributor Covenant Code of Conduct
 
-## Our Pledge
+### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, sexual identity and orientation, etc.
 
-## Our Standards
+### Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
@@ -30,17 +30,17 @@ Examples of unacceptable behavior by participants include:
 * Publishing others' private information, such as a physical or electronic address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
-## Our Responsibilities
+### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
-## Scope
+### Scope
 
 This Code of Conduct applies both within [project spaces](/organization/where) and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
-## Enforcement
+### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at moderation@joinplu.me. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
@@ -48,7 +48,7 @@ The members of the project team are the people marked as *Member of the moderati
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
-## Attribution
+### Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 

--- a/source/organization/contributors.html.md
+++ b/source/organization/contributors.html.md
@@ -4,7 +4,7 @@ summary: 'Who contributes to Plume?'
 icon: users
 ---
 
-# Ana Gelez
+## Ana Gelez
 
 **Member of the moderation team**
 
@@ -25,7 +25,7 @@ Skills:
 - Tech-related: Rust, JavaScript, HTML, CSS/SCSS, Linux
 - Languages: French (native), English (not perfect), German (not good), Esperanto (still learning)
 
-# Igor Galić
+## Igor Galić
 
 **Member of the moderation team**
 
@@ -45,7 +45,7 @@ Skills:
 - Tech-related: Unix, build systems, distributed systems, Ruby, Python, Rust
 - Languages: Bosnian (native), German (native), English (fluent)
 
-# Trinity/fdb-hiroshima
+## Trinity/fdb-hiroshima
 
 **Member of the moderation team**
 
@@ -66,7 +66,7 @@ Skills:
 - Tech-related: Rust, Linux
 - Languages: French (native), English
 
-# Want to add yourself here?
+## Want to add yourself here?
 
 You can either [do it by yourself](https://github.com/Plume-org/docs/edit/master/source/organization/contributors.html.md)
 if you have a GitHub account, or give Ana all the required informations and she will add you (see above for contact information).

--- a/source/organization/release-process.html.md
+++ b/source/organization/release-process.html.md
@@ -4,7 +4,7 @@ icon: truck
 summary: 'What we do between each releases'
 ---
 
-# Versionning
+## Versionning
 
 Plume follows semantic versionning. The 0.x series is for alpha versions. The `x` doesn't actually correspond
 to the alpha number, because `0.1.0` was before the first release, and `0.2.0` was the first alpha.
@@ -14,7 +14,7 @@ Beta versions or pre-release uses the `-rcX` suffix, where `X` is the number of 
 Major version changes when API or federation has a breaking change (they should in the same release as much as possible), not when
 major changes are made to the interface for example (even if the two are often linked).
 
-# What gets in each version
+## What gets in each version
 
 We don't set deadlines for new releases. We just assign issues (either bug to be fixed or feature requests) on GitHub to a given
 milestone as we feel it, and once it is complete, we make a new release.
@@ -23,7 +23,7 @@ milestone as we feel it, and once it is complete, we make a new release.
 
 We should prefer making small releases often, than big ones once a year or so.
 
-# The release itself
+## The release itself
 
 When we decide to make a new release, we give two weeks to translators to update translations. During this
 period bug fixes and new features are accepted, as long as they don't change the messages used in the interface.

--- a/source/organization/where.html.md
+++ b/source/organization/where.html.md
@@ -4,7 +4,7 @@ icon: share-2
 summary: 'Places where you can find Plume online'
 ---
 
-# GitHub
+## GitHub
 
 **[Plume-org on GitHub](https://github.com/Plume-org)**
 
@@ -15,33 +15,33 @@ are also hosted here.
 GitHub issues are used to list accepted features that should be implemented, or for bug reports. If a feature request needs to be discussed,
 a topic should be opened on Loomio first.
 
-# Crowdin
+## Crowdin
 
 **[Plume on Crowdin](https://crowdin.com/project/plume)**
 
 We use Crowdin to translate Plume's projects.
 
-# Matrix
+## Matrix
 
 **[#plume:disroot.org](https://riot.im/app/#/room/#plume:disroot.org)**
 
 Matrix is our main discussion and support channel. We also make announcements about the project here, so you can join it
 to stay tuned.
 
-# Loomio (Framavox)
+## Loomio (Framavox)
 
 **[Plume's Loomio group](https://framavox.org/g/WK40YHMA/plume)**
 
 Loomio is used to discuss features that need the input of the community before being included (or not).
 
-# Plume
+## Plume
 
 **[~PlumeDev@fediverse.blog](https://fediverse.blog/~/PlumeDev)**
 
 This blog is the one we use to publish news about Plume. All release articles are published here, but
 it can also be about technical aspects of the projects, or more general announcements.
 
-# Joining one of these places
+## Joining one of these places
 
 We will eventually ask you if you want to be added the GitHib organization, as a Crowdin manager, to the Matrix moderators
 or to the authors of *~PlumeDev@fediverse.blog*.


### PR DESCRIPTION
middleman's `title:` already generates an `<h1>` tag.
This means that we need to reduce all our markdown's `#` → to `##`