### PR TITLE
Add `MAIL_ADDRESS` environment variable

### DIFF
--- a/source/environment.html.md
+++ b/source/environment.html.md
@@ -22,9 +22,10 @@ meaning that all your users will get disconnected. You can generate one with `op
 The SMTP server to send mails can be configured with:
 
 - `MAIL_SERVER`: the SMTP server to connect to.
-- `MAIL_USER`: the username of the user that sends emails.
+- `MAIL_USER`: the username for authentication purposes.
 - `MAIL_PASSWORD`: its password.
 - `MAIL_HELO_NAME`: the name sent during EHLO/HELO.
+- `MAIL_ADDRESS`: the address that emails will be sent from.
 
 You can also change the logo you want to use for your instance in this file. Your logo should be in the `static` directory.
 To make Plume load it, you can use:

--- a/source/installation/config.html.md
+++ b/source/installation/config.html.md
@@ -37,6 +37,7 @@ MAIL_SERVER=smtp.example.org
 MAIL_USER=example
 MAIL_PASSWORD=123456
 MAIL_HELO_NAME=example.org
+MAIL_ADDRESS=from@example.org
 ```
 
 For more information about what you can put in your `.env`,


### PR DESCRIPTION
If `MAIL_ADDRESS` is not set in the environment, the from address is [constructed](https://github.com/rfwatson/Plume/blob/92eb13bf33c218aa4a7f6547c13aeecec2733695/src/mail.rs#L83-L86) from the `MAIL_USER` and `MAIL_SERVER` variables.

However many providers (e.g. Mailgun) require a full email address to be passed as the username. This results in a from address like `some@emailaccount@mailgun.com`. Sending emails then fails due to Lettre's [validity check](https://github.com/lettre/lettre/blob/56b718f04dbacf1456c967669e81ee40e4bcd2b1/lettre/src/lib.rs#L55), and no error is visible.

Email error handling can definitely be improved in the codebase too, but as a first step this should help new users avoid the same problem.