### PR TITLE
Docker non interactive

### DIFF
--- a/source/docker-compose.sample.yml
+++ b/source/docker-compose.sample.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - "./data/postgres:/var/lib/postgresql/data"
   plume:
-    image: plumeorg/plume:v0.3.0
+    image: plumeorg/plume:latest
     env_file: .env
     restart: unless-stopped
     volumes:

--- a/source/docker.sample.env
+++ b/source/docker.sample.env
@@ -8,6 +8,11 @@ MAIL_USER=example
 MAIL_PASSWORD=123456
 MAIL_HELO_NAME=example.org
 
+# DATABASE SETUP
+POSTGRES_PASSWORD=passw0rd
+POSTGRES_USER=plume
+POSTGRES_DB=plume
+
 # you can safely leave those defaults
 DATABASE_URL=postgres://plume:plume@postgres:5432/plume
 MIGRATION_DIRECTORY=migrations/postgres

--- a/source/docker.sample.env
+++ b/source/docker.sample.env
@@ -14,7 +14,7 @@ POSTGRES_USER=plume
 POSTGRES_DB=plume
 
 # you can safely leave those defaults
-DATABASE_URL=postgres://plume:plume@postgres:5432/plume
+DATABASE_URL=postgres://plume:passw0rd@postgres:5432/plume
 MIGRATION_DIRECTORY=migrations/postgres
 USE_HTTPS=1
 ROCKET_ADDRESS=0.0.0.0

--- a/source/installation/with/docker.html.md
+++ b/source/installation/with/docker.html.md
@@ -37,10 +37,8 @@ docker-compose pull
 
 # Launch the database container
 docker-compose up -d postgres
-# Create the database role (it will ask you for the password)
-docker-compose run --rm postgres su postgres -c 'createuser plume -dP'
-# Setup the database (create it and run migrations)
-docker-compose run --rm postgres su postgres -c 'createdb plume -O plume'
+# Wait for postgres init (user docker-compose logs to get postgres output)
+# Database setup, first migration run
 docker-compose run --rm plume plm migration run
 
 # Setup your instance

--- a/source/installation/with/docker.html.md
+++ b/source/installation/with/docker.html.md
@@ -42,8 +42,8 @@ docker-compose up -d postgres
 docker-compose run --rm plume plm migration run
 
 # Setup your instance
-docker-compose run --rm plume plm instance new
-docker-compose run --rm plume plm users new --admin
+docker-compose run --rm plume plm instance new -d 'domain.name' -n 'instance name' -l 'default licence'
+docker-compose run --rm plume plm users new -n 'admin' -N 'name' -b 'bio' -e 'admin@domain.name' -p 'pass' --admin
 docker-compose run --rm plume plm search init
 
 # Launch your instance for good


### PR DESCRIPTION
Related to https://github.com/Plume-org/docs/issues/49

Things done :

1. Postgres setup using env variables and postgres docker init script
2. Change Plume image to master in docker-compose in order to get plm migration run command
3. Replace interactive Plume setup commands