### PR TITLE
Address is spelled with two 'd's

### DIFF
--- a/source/environment.html.md
+++ b/source/environment.html.md
@@ -13,7 +13,7 @@ Here are the variables that Plume uses:
 - `BASE_URL`: the domain name, or IP and port on which Plume is listening. It is used in all federation-related code.
 - `DATABASE_URL`: the URL of the database used by Plume (`postgres://plume:plume@localhost/plume` by default with PostgreSQL, `plume.db` with SQlite).
 - `MIGRATION_DIRECTORY`: The folder that stores the migration files for the database, `migrations/postgres` for PostgreSQL databases or `migrations/sqlite` for SQlite databases.
-- `ROCKET_ADDRESS`: the adress on which Plume should listen (`0.0.0.0` by default).
+- `ROCKET_ADDRESS`: the address on which Plume should listen (`0.0.0.0` by default).
 - `ROCKET_PORT`: the port on which Plume should listen ([`7878` by default](https://twitter.com/ag_dubs/status/852559264510070784)).
 - `ROCKET_SECRET_KEY`: key used to sign private cookies and for CSRF protection. If it is not set, it will be regenerated everytime you restart Plume,
 meaning that all your users will get disconnected. You can generate one with `openssl rand -base64 32`.


### PR DESCRIPTION
I noticed a typo when reading the environment docs. Address was spelled "adress". 