### PR TITLE
fix compilation of diesel_cli

### DIFF
--- a/source/installation/with/source-code.html.md
+++ b/source/installation/with/source-code.html.md
@@ -14,7 +14,7 @@ Run the following commands.
 
 ```bash
 # Replace DATABASE with either postgres or sqlite depending on what you want to use
-cargo install diesel_cli --no-default-features --features DATABASE --version '=1.3.0'
+cargo +stable install diesel_cli --no-default-features --features DATABASE --version '=1.3.0'
 
 # Build the front-end
 cargo install cargo-web


### PR DESCRIPTION
A recent update of serde started using some feature of the std that are not available on nightly 1.35 (what we user), but was release on 1.36.0.
We can't pinpoint a past version of serde without forking diesel_cli, we can however instruct cargo to use a different rustc just for this tool to install, and this is exactly what this does