### PR TITLE
Explicitely tell where the .env file should be created

### DIFF
--- a/source/installation/config.html.md
+++ b/source/installation/config.html.md
@@ -12,6 +12,7 @@ createdb -O plume plume
 ```
 
 Before starting Plume, you'll need to create a configuration file, called `.env`.
+This file should be in the same directory as the one in which you will start Plume (`~/Plume`, if you followed the previous instructions).
 Here is a sample of what you should put inside.
 
 ```bash


### PR DESCRIPTION
It was not clear to someone.