### PR TITLE
Update search instructions

### DIFF
--- a/source/installation/config.html.md
+++ b/source/installation/config.html.md
@@ -57,17 +57,17 @@ plm migration run
 
 Migrations should be run after each update. When in doubt, run them.
 
+You will also need to initialise search index:
+
+```
+plm search init
+```
+
 After that, you'll need to setup your instance, and the admin's account.
 
 ```
 plm instance new
 plm users new --admin
-```
-
-You will also need to initialise search index
-
-```
-plm search init
 ```
 
 For more information about these commands, and the arguments you can give them,


### PR DESCRIPTION
The instructions were already here (unless something else is needed), so I just moved them up to avoid panics when creating the instance and admin account (because these commands probably open the search index even if they don't use it).